### PR TITLE
Resolved the issue : Floating point decimal places and precision and …

### DIFF
--- a/anu_ex6plus.py
+++ b/anu_ex6plus.py
@@ -35,3 +35,32 @@ z = 20.50
 print((x + y))
 print(x - z)
 
+# by jai
+floating_point_values = 0.5
+print ("%0.1f" % (floating_point_values))
+print ("%0.11f" % (floating_point_values))
+print ("%0.01f" % (floating_point_values))
+print ("%0.011f" % (floating_point_values))
+
+print("%0.1f" %(x - z))
+print("%0.11f" %(x - z))
+print("%0.01f" %(x - z))
+print(float(x - z))
+print()
+# Python stores floats with 'bits', and some floats you just can't represent accurately, no matter how many bits of
+# precision you have. This is the problem you have here. It's sorta like trying to write 1/3 in decimal with a limited
+#  amount of decimals places perfectly accurate.
+
+floating_point_values = 0.05
+print ("%0.1f" % (floating_point_values))
+print ("%0.11f" % (floating_point_values))
+print ("%0.01f" % (floating_point_values))
+print ("%0.011f" % (floating_point_values))
+print ("%0.00f" % (floating_point_values))
+print ("%0.001f" % (floating_point_values))
+print ("%0.010f" % (floating_point_values))
+
+
+# here's after all experiments
+print ("%0.2f" % (x - z))
+print ("%0.3f" % (x - z))

--- a/anu_ex8.py
+++ b/anu_ex8.py
@@ -33,3 +33,17 @@ g = a<<1  # Binary Left Shift
 print(g)
 h = b>>1  # Binary Right Shift
 print(h)
+
+# by Jai
+
+# the ~ operator
+# it is actually complement of any number
+# we represent the number in machines by 0s and 1s
+# so to speak >> in binary we have 1011010 results in 90 in decimal number system
+# now it works like -x-1
+
+
+jai = 37
+shree = ~jai
+print(jai)
+print(shree)


### PR DESCRIPTION
…accuracy with formatter.

You are running into the old problem with floating point numbers that all numbers cannot be represented. The command line is just showing you the full floating point form from memory. In floating point your rounded version is the same number. Since computers are binary they store floating point numbers as an integer and then divide it by a power of two so 13.95 will be represented in a similar fashion to 125650429603636838/(2**53). Double precision numbers have 53 bits (16 digits) of precision and regular floats have 24 bits (8 digits) of precision. The floating point in python uses double precision to store the values.